### PR TITLE
Fix Orders, Search, and Install from install_github()

### DIFF
--- a/R/planet_order.R
+++ b/R/planet_order.R
@@ -5,10 +5,8 @@
 #' This function allows you to search and order data from the Planet API
 #' @param api_key a string containing your API Key for your planet account
 #' @param aoi_dir The location of a shapefile of the area you want to search for
-#' @param start_year Defaults to 2021,
-#' @param start_doy Start Day of Year. Defaults to 158,
-#' @param end_year Defaults to 2021,
-#' @param end_doy End Day of Year. Defaults to 160,
+#' @param date_start a date object
+#' @param date_end a date object
 #' @param cloud_lim Cloud percentage from 0-1; defaults to 0.1, or 10%.
 #' @param item_name Defaults to "PSScene4Band".
 #' @param product Defaults to "analytic_sr"

--- a/R/planet_order.R
+++ b/R/planet_order.R
@@ -4,10 +4,11 @@
 #'
 #' This function allows you to search and order data from the Planet API
 #' @param api_key a string containing your API Key for your planet account
-#' @param bbox shapefile of bounding box must be EPSG:4326 Projection; no default.
-#' @param aoi_dir A shapefile of the area you want to search for
-#' @param date_end Expects as.Date; defaults to as.Date('2018-07-01')
-#' @param date_start Expects as.Date; defaults to as.Date('2018-08-01')
+#' @param aoi_dir The location of a shapefile of the area you want to search for
+#' @param start_year Defaults to 2021,
+#' @param start_doy Start Day of Year. Defaults to 158,
+#' @param end_year Defaults to 2021,
+#' @param end_doy End Day of Year. Defaults to 160,
 #' @param cloud_lim Cloud percentage from 0-1; defaults to 0.1, or 10%.
 #' @param item_name Defaults to "PSScene4Band".
 #' @param product Defaults to "analytic_sr"

--- a/R/planet_order.R
+++ b/R/planet_order.R
@@ -14,7 +14,7 @@ planet_order <- function(aoi_dir = "/Users/DataLab/Desktop/Wine Project/SMV2.geo
 #install.packages(c("here", "httr", "jsonlite", "raster","stringr"))
 
 library(sf)
-library(planetR)
+#library(planetR) #loading the package inside itself creates a circular dependency
 library(here)
 library(httr)
 library(jsonlite)

--- a/R/planet_order.R
+++ b/R/planet_order.R
@@ -5,6 +5,7 @@
 #' This function allows you to search and order data from the Planet API
 #' @param api_key a string containing your API Key for your planet account
 #' @param bbox shapefile of bounding box must be EPSG:4326 Projection; no default.
+#' @param aoi_dir A shapefile of the area you want to search for
 #' @param date_end Expects as.Date; defaults to as.Date('2018-07-01')
 #' @param date_start Expects as.Date; defaults to as.Date('2018-08-01')
 #' @param cloud_lim Cloud percentage from 0-1; defaults to 0.1, or 10%.

--- a/R/planet_order.R
+++ b/R/planet_order.R
@@ -1,6 +1,30 @@
 ##PlanetR search + Orders API for download
 
-planet_order <- function(aoi_dir = "/Users/DataLab/Desktop/Wine Project/SMV2.geojson",
+#' A function to order Planet imagery
+#'
+#' This function allows you to search and order data from the Planet API
+#' @param api_key a string containing your API Key for your planet account
+#' @param bbox shapefile of bounding box must be EPSG:4326 Projection; no default.
+#' @param date_end Expects as.Date; defaults to as.Date('2018-07-01')
+#' @param date_start Expects as.Date; defaults to as.Date('2018-08-01')
+#' @param cloud_lim Cloud percentage from 0-1; defaults to 0.1, or 10%.
+#' @param item_name Defaults to "PSScene4Band".
+#' @param product Defaults to "analytic_sr"
+#' @param order The name you want to assign to your order. Defaults to "AutomationTEST"
+#' @keywords Planet
+#' @export
+#' @examples
+#' planet_search()
+
+library(sf)
+library(here)
+library(httr)
+library(jsonlite)
+library(raster)
+library(stringr)
+
+planet_order <- function(api_key,
+                         aoi_dir,
                          start_year = 2021,
                          start_doy = 158,
                          end_year = 2021,
@@ -10,20 +34,7 @@ planet_order <- function(aoi_dir = "/Users/DataLab/Desktop/Wine Project/SMV2.geo
                          product  = "analytic_sr",
                          order = "AutomationTEST"){
 
-#remotes::install_github("bevingtona/planetR", force = T)
-#install.packages(c("here", "httr", "jsonlite", "raster","stringr"))
 
-library(sf)
-#library(planetR) #loading the package inside itself creates a circular dependency
-library(here)
-library(httr)
-library(jsonlite)
-library(raster)
-library(stringr)
-
-
-# insert api key here
-api_key = "" 
 
 #Create filters for PlanetR search
 

--- a/R/planet_order.R
+++ b/R/planet_order.R
@@ -47,8 +47,8 @@ date_end   = as.Date(paste0(end_year,"-01-01"))+end_doy
 
 
 # Set AOI - will be used to find all images that include AOI, later used to clip in Orders API
-my_aoi  = read_sf(aoi_dir)
-bbox    = extent(my_aoi)
+my_aoi = read_sf(aoi_dir)
+bbox  = extent(my_aoi)
 
 
 #SEARCH FOR IMAGES
@@ -137,7 +137,7 @@ print(paste0("Download complete, items located in ", getwd(), "/", order_name))
 }
 
 # call function (you may have to change order name to one that hasn't already been used)
-planet_order(order = "AutomationTEST_1")
+#planet_order(order = "AutomationTEST_1")
 
 
 

--- a/R/planet_order.R
+++ b/R/planet_order.R
@@ -55,11 +55,12 @@ planet_order <- function(api_key,
 #SEARCH FOR IMAGES
 
 #uses the quick search url (more info: https://developers.planet.com/docs/apis/data/reference/#tag/Item-Search)
-response <- planet_search(bbox, date_end, date_start, cloud_lim, item_name)
+response <- planet_search(bbox, date_end, date_start, cloud_lim, item_name, api_key)
 
 #ORDER API
 
-items = response$resDFid.response_doy...[1:nrow(response)]
+#items = response$resDFid.response_doy...[1:nrow(response)]
+items = response$id
 products = list(list(item_ids = items, item_type = unbox(item_name), product_bundle = unbox(product)))
 
 aoi = list(

--- a/R/planet_order.R
+++ b/R/planet_order.R
@@ -4,7 +4,7 @@
 #'
 #' This function allows you to search and order data from the Planet API
 #' @param api_key a string containing your API Key for your planet account
-#' @param aoi_dir The location of a shapefile of the area you want to search for
+#' @param bbox bounding box made with extent() from the raster package; must be EPSG:4326 Projection; no default.
 #' @param date_start a date object
 #' @param date_end a date object
 #' @param cloud_lim Cloud percentage from 0-1; defaults to 0.1, or 10%.
@@ -24,7 +24,7 @@ library(raster)
 library(stringr)
 
 planet_order <- function(api_key,
-                         aoi_dir,
+                         bbox,
                          date_start= as.Date('2021-01-01', "%Y-%m-%d"),
                          date_end= as.Date('2021-01-15', "%Y-%m-%d"),
                          # start_year = 2021,
@@ -48,8 +48,8 @@ planet_order <- function(api_key,
 
 
 # Set AOI - will be used to find all images that include AOI, later used to clip in Orders API
-my_aoi = read_sf(aoi_dir)
-bbox  = extent(my_aoi)
+#my_aoi = read_sf(aoi_dir)
+#bbox  = extent(my_aoi)
 
 
 #SEARCH FOR IMAGES

--- a/R/planet_order.R
+++ b/R/planet_order.R
@@ -27,10 +27,12 @@ library(stringr)
 
 planet_order <- function(api_key,
                          aoi_dir,
-                         start_year = 2021,
-                         start_doy = 158,
-                         end_year = 2021,
-                         end_doy = 160,
+                         date_start= as.Date('2021-01-01', "%Y-%m-%d"),
+                         date_end= as.Date('2021-01-15', "%Y-%m-%d"),
+                         # start_year = 2021,
+                         # start_doy = 158,
+                         # end_year = 2021,
+                         # end_doy = 160,
                          cloud_lim = 0.1,
                          item_name = "PSScene4Band",
                          product  = "analytic_sr",
@@ -43,8 +45,8 @@ planet_order <- function(api_key,
 # Date range of interest
 # Date range of interest
 
-date_start = as.Date(paste0(start_year,"-01-01"))+start_doy
-date_end   = as.Date(paste0(end_year,"-01-01"))+end_doy
+# date_start = as.Date(paste0(start_year,"-01-01"))+start_doy
+# date_end   = as.Date(paste0(end_year,"-01-01"))+end_doy
 
 
 # Set AOI - will be used to find all images that include AOI, later used to clip in Orders API

--- a/R/planet_search.R
+++ b/R/planet_search.R
@@ -6,6 +6,7 @@
 #' @param date_start Expects as.Date; defaults to as.Date('2018-08-01')
 #' @param cloud_lim Cloud percentage from 0-1; defaults to 0.1, or 10%.
 #' @param item_name Defaults to "PSOrthoTile".
+#' @param api_key your planet api key string
 #' @keywords Planet
 #' @export
 #' @examples
@@ -22,7 +23,8 @@ planet_search <- function(bbox ,
                           date_end = as.Date('2018-07-01'),
                           date_start = as.Date('2018-08-01'),
                           cloud_lim = 0.1,
-                          item_name = "PSOrthoTile")
+                          item_name = "PSOrthoTile",
+                          api_key)
 
   {
 

--- a/R/planet_search.R
+++ b/R/planet_search.R
@@ -108,25 +108,9 @@ planet_search <- function(bbox ,
     resID = res$features$id
     resDFid <- rbind(resDFid, data.frame(id = resID))
     }
-
-
-  response_doy <- as.numeric(
-    format(
-      as.Date.character(
-        str_split_fixed(
-          resDFid$id,
-          pattern = "_",n = 2)[,1],
-        format = "%Y%m%d"),
-      format = "%j")
-  )
-
-  response_doy <- (response_doy > start_doy & response_doy < end_doy)
-
-  resDFid_doy <- data.frame(resDFid[response_doy,])
-
+  
   print(paste(nrow(resDFid),"images ... between", date_start, "and", date_end))
-  print(paste(nrow(resDFid_doy),"images ... that meet all criteria"))
 
-  return(resDFid_doy)
+  return(resDFid)
 }
 

--- a/R/planet_search.R
+++ b/R/planet_search.R
@@ -1,7 +1,7 @@
 #' A function to search Planet imagery
 #'
 #' This function allows you to search the Planet API
-#' @param bbox shapefile of bounding box must be EPSG:4326 Projection; no default.
+#' @param bbox bounding box made with extent() from the raster package; must be EPSG:4326 Projection; no default.
 #' @param date_end Expects as.Date; defaults to as.Date('2018-07-01')
 #' @param date_start Expects as.Date; defaults to as.Date('2018-08-01')
 #' @param cloud_lim Cloud percentage from 0-1; defaults to 0.1, or 10%.


### PR DESCRIPTION
This PR fixes:

- the circular dependency when you try to install this package using install_github() caused by a call to the planetR package in the planet_orders() function
- makes the planet_orders() function work with recent changes to the response from Planet's API and makes the function valid for use in a package
- applies @tnelsen 's PR that resolves the error in the planet_search() function related to unused parameters

I successfully used the upgraded planet_search() and planet_order() functions to search for a small area of interest and order a clipped scene from the Planet API.

I'm glad for the opportunity to help improve this package. It's very needed and fills a gap in using the Planet API with R.